### PR TITLE
Change order of function calls in commit_default_style() method

### DIFF
--- a/src/liborcus/odf_styles_context.cpp
+++ b/src/liborcus/odf_styles_context.cpp
@@ -718,9 +718,9 @@ void styles_context::commit_default_styles()
     mp_styles->commit_border();
     mp_styles->commit_cell_protection();
     mp_styles->commit_number_format();
-    mp_styles->commit_cell_style();
     mp_styles->commit_cell_style_xf();
     mp_styles->commit_cell_xf();
+    mp_styles->commit_cell_style();
 }
 
 }


### PR DESCRIPTION
This commit prevents libreoffice to crash because of wrong order
of function call